### PR TITLE
distinguish scope name for each grammar

### DIFF
--- a/grammars/ect_html.cson
+++ b/grammars/ect_html.cson
@@ -420,4 +420,4 @@
         'include': '#string-single-quoted'
       }
     ]
-'scopeName': 'text.html.basic.ect'
+'scopeName': 'text.html.basic.ect3'

--- a/grammars/ect_html.cson
+++ b/grammars/ect_html.cson
@@ -420,4 +420,4 @@
         'include': '#string-single-quoted'
       }
     ]
-'scopeName': 'text.html.basic.ect3'
+'scopeName': 'text.html.basic.ect'

--- a/grammars/ect_html2.cson
+++ b/grammars/ect_html2.cson
@@ -420,4 +420,4 @@
         'include': '#string-single-quoted'
       }
     ]
-'scopeName': 'text.html.basic.ect'
+'scopeName': 'text.html.basic.ect2'

--- a/grammars/ect_html3.cson
+++ b/grammars/ect_html3.cson
@@ -420,4 +420,4 @@
         'include': '#string-single-quoted'
       }
     ]
-'scopeName': 'text.html.basic.ect'
+'scopeName': 'text.html.basic.ect3'

--- a/grammars/ect_html4.cson
+++ b/grammars/ect_html4.cson
@@ -420,4 +420,4 @@
         'include': '#string-single-quoted'
       }
     ]
-'scopeName': 'text.html.basic.ect'
+'scopeName': 'text.html.basic.ect4'


### PR DESCRIPTION
I think each grammar could/should have a unique scopeName? My particular use case is for configuring file-types package for directly matching languages based on filename
